### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,11 +6,11 @@ This is a simple iOS client for [hackfoldr](https://github.com/hackfoldr/hackfol
 
 ## Why? ##
 
-Hackfoldr on mobile is not good enought on iOS, let it simply.
+Hackfoldr on mobile is simply not good enough on iOS.
 
 ## Use CocoaPods developer ##
 
-[CocoaPods](http://cocoapods.org/) is easy way install iOS third-party component
+[CocoaPods](http://cocoapods.org/) is the easy way to install third-party iOS components.
 
 ````
 pod install

--- a/Readme.md
+++ b/Readme.md
@@ -8,9 +8,9 @@ This is a simple iOS client for [hackfoldr](https://github.com/hackfoldr/hackfol
 
 Hackfoldr on mobile is not good enought on iOS, let it simply.
 
-## Use cocoapods developer ##
+## Use CocoaPods developer ##
 
-[cocoapods](http://cocoapods.org/) is easy way install iOS third-party component
+[CocoaPods](http://cocoapods.org/) is easy way install iOS third-party component
 
 ````
 pod install


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
